### PR TITLE
Faster categorical column names selection

### DIFF
--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Set, Tuple, Un
 
 import numpy as np
 import scipy.sparse
+from pandas import CategoricalDtype
 
 from .compat import PANDAS_INSTALLED, concat, dt_DataTable, is_dtype_sparse, pd_DataFrame, pd_Series
 from .libpath import find_lib_path
@@ -566,7 +567,7 @@ def _data_from_pandas(data, feature_name, categorical_feature, pandas_categorica
             raise ValueError('Input data must be 2 dimensional and non empty.')
         if feature_name == 'auto' or feature_name is None:
             data = data.rename(columns=str)
-        cat_cols = list(data.select_dtypes(include=['category']).columns)
+        cat_cols = [col for col, t in zip(data.columns, data.dtypes) if isinstance(t, CategoricalDtype)]
         cat_cols_not_ordered = [col for col in cat_cols if not data[col].cat.ordered]
         if pandas_categorical is None:  # train dataset
             pandas_categorical = [list(data[col].cat.categories) for col in cat_cols]

--- a/python-package/lightgbm/basic.py
+++ b/python-package/lightgbm/basic.py
@@ -567,7 +567,7 @@ def _data_from_pandas(data, feature_name, categorical_feature, pandas_categorica
             raise ValueError('Input data must be 2 dimensional and non empty.')
         if feature_name == 'auto' or feature_name is None:
             data = data.rename(columns=str)
-        cat_cols = [col for col, t in zip(data.columns, data.dtypes) if isinstance(t, CategoricalDtype)]
+        cat_cols = [col for col, dtype in zip(data.columns, data.dtypes) if isinstance(dtype, CategoricalDtype)]
         cat_cols_not_ordered = [col for col in cat_cols if not data[col].cat.ordered]
         if pandas_categorical is None:  # train dataset
             pandas_categorical = [list(data[col].cat.categories) for col in cat_cols]


### PR DESCRIPTION
Change slow and redundant dataframe query by select_dtypes into a dataframe.dtypes list comprehension

```
import pandas as pd
import random
temp_df = pd.DataFrame({str(a):[random.random() for _ in range(100)] for a in range(200)})
temp_df[["100", "121", "115"]] = temp_df[["100", "121", "115"]].astype("category")
```

`%timeit temp_df.select_dtypes("category").columns`->`23.1 ms ± 1.04 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`

VS

`%timeit [col for col, t in zip(temp_df.columns, temp_df.dtypes) if isinstance(t, CategoricalDtype)]` ->`167 µs ± 16.4 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)`
